### PR TITLE
feat: add gitopsapi delete operation

### DIFF
--- a/controllers/gitopsapi_controller.go
+++ b/controllers/gitopsapi_controller.go
@@ -141,7 +141,10 @@ func GetKustomizaton(fs billy.Filesystem, path string) (*types.Kustomization, er
 	if err != nil {
 		return nil, err
 	}
-	existingKustomization, _ := ioutil.ReadAll(existing)
+	existingKustomization, err := ioutil.ReadAll(existing)
+	if err != nil {
+		return &kustomization, err
+	}
 	if err := yaml.Unmarshal(existingKustomization, &kustomization); err != nil {
 		return nil, err
 	}
@@ -192,7 +195,10 @@ func CreateOrUpdateObject(ctx context.Context, logger logr.Logger, git connector
 	if index == -1 {
 		kustomization.Resources = append(kustomization.Resources, relativePath)
 	}
-	existingKustomization, _ := yaml.Marshal(kustomization)
+	existingKustomization, err := yaml.Marshal(kustomization)
+	if err != nil {
+		return
+	}
 	if err = copy(existingKustomization, api.Spec.Kustomization, fs, work); err != nil {
 		return
 	}

--- a/controllers/utils.go
+++ b/controllers/utils.go
@@ -3,6 +3,7 @@ package controllers
 import (
 	"bytes"
 	"io"
+	"os"
 
 	"github.com/go-git/go-billy/v5"
 	gitv5 "github.com/go-git/go-git/v5"
@@ -25,6 +26,32 @@ func copy(data []byte, path string, fs billy.Filesystem, work *gitv5.Worktree) e
 	return errors.Wrap(err, "failed to add to git")
 }
 
+func deleteFile(path string, work *gitv5.Worktree, repoRoot string) error {
+	fullPath := repoRoot + "/" + path
+	err := os.Remove(fullPath)
+	if err != nil {
+		return errors.Wrap(err, "failed to delete file")
+	}
+	_, err = work.Add(path)
+	if err != nil {
+		return errors.Wrap(err, "failed to add to git")
+	}
+	return nil
+}
+
 func openOrCreate(path string, fs billy.Filesystem) (billy.File, error) {
 	return fs.Create(path)
+}
+
+func findElement(list []string, element string) int {
+	for i := range list {
+		if list[i] == element {
+			return i
+		}
+	}
+	return -1
+}
+
+func removeElement(list []string, indext int) []string {
+	return append(list[:indext], list[indext+1:]...)
 }

--- a/controllers/utils.go
+++ b/controllers/utils.go
@@ -4,6 +4,8 @@ import (
 	"bytes"
 	"io"
 	"os"
+	"strings"
+	"unicode"
 
 	"github.com/go-git/go-billy/v5"
 	gitv5 "github.com/go-git/go-git/v5"
@@ -54,4 +56,20 @@ func findElement(list []string, element string) int {
 
 func removeElement(list []string, indext int) []string {
 	return append(list[:indext], list[indext+1:]...)
+}
+
+func TabToSpace(input string) string {
+	var result []string
+
+	for _, i := range input {
+		switch {
+		// all these considered as space, including tab \t
+		// '\t', '\n', '\v', '\f', '\r',' ', 0x85, 0xA0
+		case unicode.IsSpace(i):
+			result = append(result, " ") // replace tab with space
+		case !unicode.IsSpace(i):
+			result = append(result, string(i))
+		}
+	}
+	return strings.Join(result, "")
 }

--- a/test/e2e.go
+++ b/test/e2e.go
@@ -172,7 +172,7 @@ func TestGitopsAPI(ctx context.Context, test *console.TestResults) error {
 				Body:  "Somebody created a new PR {{.metadata.name}}",
 			},
 		},
-	}, bytes.NewReader([]byte(body)))
+	}, bytes.NewReader([]byte(body)), false)
 
 	if pr != 0 {
 		if err := git.ClosePullRequest(ctx, pr); err != nil {
@@ -216,7 +216,7 @@ func TestGitopsAPISearchPath(ctx context.Context, test *console.TestResults) err
 				Body:  "Somebody created a new PR {{.metadata.name}}",
 			},
 		},
-	}, bytes.NewReader([]byte(body)))
+	}, bytes.NewReader([]byte(body)), false)
 
 	if pr != 0 {
 		if err := git.ClosePullRequest(ctx, pr); err != nil {


### PR DESCRIPTION
### Description

Exposed a different endpoint starting with `/_delete` to let the server know that the request is for delete object

### Breaking Change

- [ ] Yes
- [x] No

### Testing Notes

Created a gitopsapi object and sent a post request with a object to the delete endpoint to see it gets deleted
GitOpsApi object used:
```yaml
apiVersion: git.flanksource.com/v1
kind: GitopsAPI
metadata:
  name: gitopsapi-sample
spec:
  gitRepository: https://github.com/Kaitou786/test-gitops-api.git
  kustomization: clusters/dev01/kustomization.yaml
  secretRef:
    name: git-operator-test
  tokenRef:
    name: token
  branch: random
  searchPath: "clusters/"
  pullRequest:
    body: "my test PR"
    title: "some awesome title"
```

The post data
```jsom
{
  "apiVersion": "acmp.corp/v1",
  "kind": "NamespaceRequest",
  "metadata": {
    "name": "tenant3",
    "annotations": {
      "a": "b"
    },
    "labels": {
      "c": "d"
    }
  },
  "spec": {
    "memory": 10,
    "cluster": "dev01"
  },
  "cluster": "dev02"
}
```

The Curl request:
```
 curl -X POST 'localhost:8888/_delete/default/gitopsapi-sample/mypassword' -d @data.json
 ```

See my testing PR: https://github.com/Kaitou786/test-gitops-api/pull/15
**How you can replicate my testing:**
_How can the reviewer validate this PR?_


### **Links**

_Issues links or other related resources_